### PR TITLE
fix(): BlockHeightSwCache can not used to graphql fromHeight

### DIFF
--- a/src/plugins/CacheableContractInteractionsLoader.ts
+++ b/src/plugins/CacheableContractInteractionsLoader.ts
@@ -52,7 +52,7 @@ export class CacheableContractInteractionsLoader implements InteractionsLoader {
 
     const missingInteractions = await this.baseImplementation.load(
       contractId,
-      cachedHeight + 1,
+      fromBlockHeight,
       toBlockHeight,
       evaluationOptions
     );


### PR DESCRIPTION
when use CacheableContractInteractionsLoader model run swc
can not use BlockHeightSwCache.cacheHeight to load next graphql fromHeight.
It is possible that the block height of the grapghql gateway is not equal to the block height of the current chain.
So I think we should use the height of the cache in the stateEvaluator.
This situation may cause graphql to request the same data repeatedly, but avoids the loss of data