### PR TITLE
Ppe/file cache fix

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,8 @@ module.exports = {
 
   testPathIgnorePatterns: [
     "/.yalc/",
-    "/data/"
+    "/data/",
+    "/_helpers",
   ],
 
   testEnvironment: 'node',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "redstone-smartweave",
   "version": "0.4.0",
-  "description": "An implementation of the SmartWeave SDK.",
+  "description": "An implementation of the SmartWeave smart contract protocol.",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/types/index.d.ts",
@@ -56,7 +56,6 @@
     "arweave-multihost": "^0.1.0",
     "axios": "^0.21.4",
     "bignumber.js": "^9.0.1",
-    "bson": "^4.5.0",
     "json-beautify": "^1.1.1",
     "lodash": "^4.17.21",
     "tslog": "^3.2.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redstone-smartweave",
-  "version": "0.3.10-alpha.19",
+  "version": "0.4.0",
   "description": "An implementation of the SmartWeave SDK.",
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
@@ -67,7 +67,7 @@
     "@types/node": "^16.7.1",
     "@typescript-eslint/eslint-plugin": "^4.29.2",
     "@typescript-eslint/parser": "^4.29.2",
-    "arlocal": "1.1.4",
+    "arlocal": "1.1.13",
     "cheerio": "^1.0.0-rc.10",
     "cors": "^2.8.5",
     "eslint": "^7.32.0",

--- a/src/__tests__/integration/_helpers.ts
+++ b/src/__tests__/integration/_helpers.ts
@@ -1,0 +1,11 @@
+import Arweave from 'arweave';
+import { JWKInterface } from 'arweave/node/lib/wallet';
+
+export async function addFunds(arweave: Arweave, wallet: JWKInterface) {
+  const walletAddress = await arweave.wallets.getAddress(wallet);
+  await arweave.api.get(`/mint/${walletAddress}/1000000000000000`);
+}
+
+export async function mineBlock(arweave: Arweave) {
+  await arweave.api.get('mine');
+}

--- a/src/__tests__/integration/complicated-contract.test.ts
+++ b/src/__tests__/integration/complicated-contract.test.ts
@@ -5,6 +5,7 @@ import Arweave from 'arweave';
 import { JWKInterface } from 'arweave/node/lib/wallet';
 import { Contract, LoggerFactory, SmartWeave, SmartWeaveNodeFactory } from '@smartweave';
 import path from 'path';
+import { addFunds, mineBlock } from './_helpers';
 
 let arweave: Arweave;
 let arlocal: ArLocal;
@@ -36,6 +37,7 @@ describe('Testing the SmartWeave client', () => {
     smartweave = SmartWeaveNodeFactory.memCached(arweave);
 
     wallet = await arweave.wallets.generate();
+    await addFunds(arweave, wallet);
 
     contractSrc = fs.readFileSync(path.join(__dirname, 'data/very-complicated-contract.js'), 'utf8');
 
@@ -49,7 +51,7 @@ describe('Testing the SmartWeave client', () => {
     contract = smartweave.contract(contractTxId);
     contract.connect(wallet);
 
-    await mine();
+    await mineBlock(arweave);
   });
 
   afterAll(async () => {
@@ -60,7 +62,3 @@ describe('Testing the SmartWeave client', () => {
     expect(await contract.readState()).not.toBeUndefined();
   });
 });
-
-async function mine() {
-  await arweave.api.get('mine');
-}

--- a/src/__tests__/integration/data/staking/erc-20.js
+++ b/src/__tests__/integration/data/staking/erc-20.js
@@ -25,9 +25,6 @@ export function handle(state, action) {
     if (!_allowances[_msgSender]) {
       _allowances[_msgSender] = {};
     }
-    if (!_allowances[_msgSender][spender]) {
-      _allowances[_msgSender][spender] = {};
-    }
 
     _allowances[_msgSender][spender] = amount;
 

--- a/src/__tests__/integration/deploy-write-read.test.ts
+++ b/src/__tests__/integration/deploy-write-read.test.ts
@@ -52,11 +52,13 @@ describe('Testing the SmartWeave client', () => {
     initialState = fs.readFileSync(path.join(__dirname, 'data/example-contract-state.json'), 'utf8');
 
     // deploying contract using the new SDK.
+    await addFunds();
     const contractTxId = await smartweave.createContract.deploy({
       wallet,
       initState: initialState,
       src: contractSrc
     });
+
 
     contract = smartweave.contract(contractTxId);
     contract.connect(wallet);
@@ -98,5 +100,10 @@ describe('Testing the SmartWeave client', () => {
 
   async function mine() {
     await arweave.api.get('mine');
+  }
+
+  async function addFunds() {
+    const walletAddress = await arweave.wallets.getAddress(wallet);
+    await arweave.api.get(`/mint/${walletAddress}/1000`);
   }
 });

--- a/src/__tests__/integration/internal-writes/internal-write-callee.test.ts
+++ b/src/__tests__/integration/internal-writes/internal-write-callee.test.ts
@@ -7,6 +7,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 import { Contract, LoggerFactory, SmartWeave, SmartWeaveNodeFactory } from '@smartweave';
 import path from 'path';
 import { TsLogFactory } from '../../../logging/node/TsLogFactory';
+import { addFunds, mineBlock } from '../_helpers';
 
 interface ExampleContractState {
   counter: number;
@@ -65,7 +66,6 @@ describe('Testing internal writes', () => {
       protocol: 'http'
     });
 
-    LoggerFactory.use(new TsLogFactory());
     LoggerFactory.INST.logLevel('error');
   });
 
@@ -77,6 +77,7 @@ describe('Testing internal writes', () => {
     smartweave = SmartWeaveNodeFactory.memCached(arweave);
 
     wallet = await arweave.wallets.generate();
+    await addFunds(arweave, wallet);
 
     callingContractSrc = fs.readFileSync(path.join(__dirname, '../data/writing-contract.js'), 'utf8');
     callingContractInitialState = fs.readFileSync(path.join(__dirname, '../data/writing-contract-state.json'), 'utf8');
@@ -108,7 +109,7 @@ describe('Testing internal writes', () => {
       })
       .connect(wallet);
 
-    await mine();
+    await mineBlock(arweave);
   }
 
   describe('with read states in between', () => {
@@ -123,60 +124,60 @@ describe('Testing internal writes', () => {
     it('should write direct interactions', async () => {
       await calleeContract.writeInteraction({ function: 'add' });
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
       expect((await calleeContract.readState()).state.counter).toEqual(557);
     });
 
     it('should write one direct and one internal interaction', async () => {
       await calleeContract.writeInteraction({ function: 'add' });
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
       expect((await calleeContract.readState()).state.counter).toEqual(568);
     });
 
     it('should write another direct interaction', async () => {
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
       expect((await calleeContract.readState()).state.counter).toEqual(569);
     });
 
     it('should write double internal interaction with direct interaction', async () => {
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
       expect((await calleeContract.readState()).state.counter).toEqual(590);
     });
 
     it('should write combination of internal and direct interaction', async () => {
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
       expect((await calleeContract.readState()).state.counter).toEqual(601);
     });
 
     it('should write combination of internal and direct interaction', async () => {
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
       expect((await calleeContract.readState()).state.counter).toEqual(612);
     });
 
     it('should write combination of direct and internal interaction - at one block', async () => {
       await calleeContract.writeInteraction({ function: 'add' });
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
       expect((await calleeContract.readState()).state.counter).toEqual(623);
     });
 
     it('should write combination of direct and internal interaction - on different blocks', async () => {
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
       expect((await calleeContract.readState()).state.counter).toEqual(634);
     });
 
@@ -193,39 +194,39 @@ describe('Testing internal writes', () => {
     it('should properly write a combination of direct and internal interactions', async () => {
       await calleeContract.writeInteraction({ function: 'add' });
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await calleeContract.writeInteraction({ function: 'add' });
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
 
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await calleeContract.writeInteraction({ function: 'add' });
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
 
       await callingContract.writeInteraction({ function: 'writeContract', contractId: calleeTxId, amount: 10 });
-      await mine();
+      await mineBlock(arweave);
       await calleeContract.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
       expect((await calleeContract.readState()).state.counter).toEqual(634);
     });
 
@@ -242,8 +243,4 @@ describe('Testing internal writes', () => {
       expect((await calleeContract2.readState()).state.counter).toEqual(634);
     });
   });
-
-  async function mine() {
-    await arweave.api.get('mine');
-  }
 });

--- a/src/__tests__/integration/internal-writes/internal-write-depth.test.ts
+++ b/src/__tests__/integration/internal-writes/internal-write-depth.test.ts
@@ -7,6 +7,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 import { Contract, LoggerFactory, SmartWeave, SmartWeaveNodeFactory } from '@smartweave';
 import path from 'path';
 import { TsLogFactory } from '../../../logging/node/TsLogFactory';
+import { addFunds, mineBlock } from '../_helpers';
 
 /**
  * This test verifies "deep" writes between
@@ -91,6 +92,7 @@ describe('Testing internal writes', () => {
     smartweave = SmartWeaveNodeFactory.memCached(arweave);
 
     wallet = await arweave.wallets.generate();
+    await addFunds(arweave, wallet);
 
     contractASrc = fs.readFileSync(path.join(__dirname, '../data/writing-contract.js'), 'utf8');
     contractAInitialState = fs.readFileSync(path.join(__dirname, '../data/writing-contract-state.json'), 'utf8');
@@ -134,7 +136,7 @@ describe('Testing internal writes', () => {
       })
       .connect(wallet);
 
-    await mine();
+    await mineBlock(arweave);
   }
 
   describe('with read states in between', () => {
@@ -152,7 +154,7 @@ describe('Testing internal writes', () => {
       await contractB.writeInteraction({ function: 'add' });
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(557);
       expect((await contractC.readState()).state.counter).toEqual(201);
@@ -165,7 +167,7 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(567);
       expect((await contractC.readState()).state.counter).toEqual(231);
@@ -186,7 +188,7 @@ describe('Testing internal writes', () => {
       await contractB.writeInteraction({ function: 'add' });
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractA.writeInteraction({
         function: 'writeInDepth',
@@ -194,7 +196,7 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(567);
       expect((await contractC.readState()).state.counter).toEqual(231);
@@ -228,7 +230,7 @@ describe('Testing internal writes', () => {
       await contractB.writeInteraction({ function: 'add' });
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractA.writeInteraction({
         function: 'writeInDepth',
@@ -236,7 +238,7 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(567);
     });
@@ -260,7 +262,7 @@ describe('Testing internal writes', () => {
       await contractB.writeInteraction({ function: 'add' });
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractA.writeInteraction({
         function: 'writeInDepth',
@@ -268,7 +270,7 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractC.readState()).state.counter).toEqual(231);
     });
@@ -296,7 +298,7 @@ describe('Testing internal writes', () => {
       await contractB.writeInteraction({ function: 'add' });
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractA.writeInteraction({
         function: 'writeInDepth',
@@ -304,7 +306,7 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractC.readState()).state.counter).toEqual(231);
       expect((await contractC.readState()).state.counter).toEqual(231);
@@ -319,7 +321,7 @@ describe('Testing internal writes', () => {
       await contractB.writeInteraction({ function: 'add' });
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractA.writeInteraction({
         function: 'writeInDepth',
@@ -327,13 +329,9 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
 
       await expect(contractC.readState()).rejects.toThrow(/(.)*Error: Max call depth(.*)/);
     });
   });
-
-  async function mine() {
-    await arweave.api.get('mine');
-  }
 });

--- a/src/__tests__/integration/internal-writes/multi-internal-calls.test.ts
+++ b/src/__tests__/integration/internal-writes/multi-internal-calls.test.ts
@@ -7,6 +7,7 @@ import { JWKInterface } from 'arweave/node/lib/wallet';
 import { Contract, LoggerFactory, SmartWeave, SmartWeaveNodeFactory } from '@smartweave';
 import path from 'path';
 import { TsLogFactory } from '../../../logging/node/TsLogFactory';
+import { addFunds, mineBlock } from '../_helpers';
 
 /**
  * This test verifies multiple internal calls from
@@ -85,6 +86,7 @@ describe('Testing internal writes', () => {
     smartweave = SmartWeaveNodeFactory.memCached(arweave);
 
     wallet = await arweave.wallets.generate();
+    await addFunds(arweave, wallet);
 
     contractASrc = fs.readFileSync(path.join(__dirname, '../data/writing-contract.js'), 'utf8');
     contractAInitialState = fs.readFileSync(path.join(__dirname, '../data/writing-contract-state.json'), 'utf8');
@@ -113,7 +115,7 @@ describe('Testing internal writes', () => {
     contractB = smartweave.contract(contractBTxId).setEvaluationOptions({ internalWrites: true }).connect(wallet);
     contractC = smartweave.contract(contractCTxId).setEvaluationOptions({ internalWrites: true }).connect(wallet);
 
-    await mine();
+    await mineBlock(arweave);
   }
 
   describe('with read states in between', () => {
@@ -131,7 +133,7 @@ describe('Testing internal writes', () => {
       await contractB.writeInteraction({ function: 'add' });
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(557);
       expect((await contractC.readState()).state.counter).toEqual(201);
@@ -146,7 +148,7 @@ describe('Testing internal writes', () => {
         amount: 10
       });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(568);
       expect((await contractC.readState()).state.counter).toEqual(212);
@@ -155,7 +157,7 @@ describe('Testing internal writes', () => {
     it('should properly create multiple internal calls (3)', async () => {
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(569);
       expect((await contractC.readState()).state.counter).toEqual(213);
@@ -175,10 +177,10 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(590);
       expect((await contractC.readState()).state.counter).toEqual(235);
@@ -191,9 +193,9 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
       await contractB.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(601);
       expect((await contractC.readState()).state.counter).toEqual(245);
@@ -206,10 +208,10 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(612);
       expect((await contractC.readState()).state.counter).toEqual(256);
@@ -223,7 +225,7 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
 
       await contractA.writeInteraction({
         function: 'writeMultiContract',
@@ -231,9 +233,9 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
       await contractB.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(634);
       expect((await contractC.readState()).state.counter).toEqual(276);
@@ -254,7 +256,7 @@ describe('Testing internal writes', () => {
       await contractB.writeInteraction({ function: 'add' });
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractB.writeInteraction({ function: 'add' });
       await contractA.writeInteraction({
@@ -264,11 +266,11 @@ describe('Testing internal writes', () => {
         amount: 10
       });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractA.writeInteraction({
         function: 'writeMultiContract',
@@ -283,10 +285,10 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractA.writeInteraction({
         function: 'writeMultiContract',
@@ -294,9 +296,9 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
       await contractB.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractA.writeInteraction({
         function: 'writeMultiContract',
@@ -304,10 +306,10 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
       await contractB.writeInteraction({ function: 'add' });
       await contractC.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       await contractB.writeInteraction({ function: 'add' });
       await contractA.writeInteraction({
@@ -316,7 +318,7 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
 
       await contractA.writeInteraction({
         function: 'writeMultiContract',
@@ -324,9 +326,9 @@ describe('Testing internal writes', () => {
         contractId2: contractCTxId,
         amount: 10
       });
-      await mine();
+      await mineBlock(arweave);
       await contractB.writeInteraction({ function: 'add' });
-      await mine();
+      await mineBlock(arweave);
 
       expect((await contractB.readState()).state.counter).toEqual(634);
       expect((await contractC.readState()).state.counter).toEqual(276);
@@ -350,8 +352,4 @@ describe('Testing internal writes', () => {
       expect((await contractC2.readState()).state.counter).toEqual(276);
     });
   });
-
-  async function mine() {
-    await arweave.api.get('mine');
-  }
 });

--- a/src/cache/BlockHeightSwCache.ts
+++ b/src/cache/BlockHeightSwCache.ts
@@ -29,6 +29,11 @@ export interface BlockHeightSwCache<V> {
    * checks whether cache has any value stored for given cache key
    */
   contains(key: string): Promise<boolean>;
+
+  /**
+   * flushes cache to underneath storage (if available)
+   */
+  flush(): Promise<void>;
 }
 
 export class BlockHeightKey {

--- a/src/cache/impl/MemBlockHeightCache.ts
+++ b/src/cache/impl/MemBlockHeightCache.ts
@@ -12,10 +12,6 @@ export class MemBlockHeightSwCache<V = any> implements BlockHeightSwCache<V> {
 
   constructor(private maxStoredBlockHeights: number = Number.MAX_SAFE_INTEGER) {}
 
-  flush(): Promise<void> {
-    throw new Error('Method not implemented.');
-  }
-
   async getLast(key: string): Promise<BlockHeightCacheResult<V> | null> {
     if (!(await this.contains(key))) {
       return null;
@@ -83,5 +79,9 @@ export class MemBlockHeightSwCache<V = any> implements BlockHeightSwCache<V> {
       cachedHeight: blockHeight,
       cachedValue: returnDeepCopy ? deepCopy(this.storage[key].get(blockHeight)) : this.storage[key].get(blockHeight)
     };
+  }
+
+  flush(): Promise<void> {
+    return Promise.resolve(undefined);
   }
 }

--- a/src/cache/impl/RemoteBlockHeightCache.ts
+++ b/src/cache/impl/RemoteBlockHeightCache.ts
@@ -67,4 +67,8 @@ export class RemoteBlockHeightCache<V = any> implements BlockHeightSwCache<V> {
     const response = await this.axios.get<BlockHeightCacheResult<V> | null>(`/${this.type}/${key}/${blockHeight}`);
     return response.data || null;
   }
+
+  flush(): Promise<void> {
+    return Promise.resolve(undefined);
+  }
 }

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -1,4 +1,4 @@
-export * from './impl/BsonFileBlockHeightCache';
+export * from './impl/FileBlockHeightCache';
 export * from './impl/MemBlockHeightCache';
 export * from './impl/RemoteBlockHeightCache';
 export * from './impl/MemCache';

--- a/src/core/SmartWeaveBuilder.ts
+++ b/src/core/SmartWeaveBuilder.ts
@@ -1,5 +1,6 @@
 import Arweave from 'arweave';
 import {
+  BlockHeightSwCache,
   DebuggableExecutorFactory,
   DefinitionLoader,
   ExecutorFactory,

--- a/src/core/modules/impl/CacheableStateEvaluator.ts
+++ b/src/core/modules/impl/CacheableStateEvaluator.ts
@@ -124,6 +124,7 @@ export class CacheableStateEvaluator extends DefaultStateEvaluator {
 
     this.cLogger.debug(`onStateEvaluated: cache update for contract ${contractTxId} [${transaction.block.height}]`);
     await this.putInCache(contractTxId, transaction, state);
+    await this.cache.flush();
   }
 
   async onStateUpdate<State>(
@@ -205,7 +206,6 @@ export class CacheableStateEvaluator extends DefaultStateEvaluator {
     const blockHeight = transaction.block.height;
 
     const stateToCache = new EvalStateResult(state.state, state.validity, transactionId, transaction.block.id);
-    await this.cache.put(new BlockHeightKey(contractTxId, blockHeight), [stateToCache]);
 
     // we do not return a deepCopy here - as this operation significantly (2-3x) degrades performance
     // for contracts with multiple interactions on single block height

--- a/src/core/modules/impl/DefaultCreateContract.ts
+++ b/src/core/modules/impl/DefaultCreateContract.ts
@@ -9,7 +9,7 @@ export class DefaultCreateContract implements CreateContract {
     this.deployFromSourceTx = this.deployFromSourceTx.bind(this);
   }
 
-  async deploy(contractData: ContractData) {
+  async deploy(contractData: ContractData): Promise<string> {
     this.logger.debug('Creating new contract');
 
     const { wallet, src, initState, tags, transfer } = contractData;

--- a/src/core/node/SmartWeaveNodeFactory.ts
+++ b/src/core/node/SmartWeaveNodeFactory.ts
@@ -10,7 +10,7 @@ import {
   SmartWeaveWebFactory
 } from '@smartweave/core';
 import { CacheableContractInteractionsLoader, CacheableExecutorFactory, Evolve } from '@smartweave/plugins';
-import { BsonFileBlockHeightSwCache, MemBlockHeightSwCache, MemCache } from '@smartweave/cache';
+import { DEFAULT_BATCH_SIZE, FileBlockHeightSwCache, MemBlockHeightSwCache, MemCache } from '@smartweave/cache';
 
 /**
  * A {@link SmartWeave} factory that can be safely used only in Node.js env.
@@ -19,16 +19,25 @@ export class SmartWeaveNodeFactory extends SmartWeaveWebFactory {
   /**
    * Returns a fully configured {@link SmartWeave} that is using file-based cache for {@link StateEvaluator} layer
    * and mem cache for the rest.
+   *
+   * @param cacheBasePath - path where cache files will be stored
+   * @param batchSize - how many cache entries will be flushed to underneath storage at once. Note: setting
+   * this to "1" (or in general - "small" value) may slow down the contract execution, as cache will be flushed
+   * after each put (eg. after evaluating state for each interaction transaction)
+   *
    */
-  static fileCached(arweave: Arweave, cacheBasePath?: string): SmartWeave {
-    return this.fileCachedBased(arweave, cacheBasePath).build();
+  static fileCached(arweave: Arweave, cacheBasePath?: string, batchSize = DEFAULT_BATCH_SIZE): SmartWeave {
+    return this.fileCachedBased(arweave, cacheBasePath, batchSize).build();
   }
 
   /**
    * Returns a preconfigured, fileCached {@link SmartWeaveBuilder}, that allows for customization of the SmartWeave instance.
    * Use {@link SmartWeaveBuilder.build()} to finish the configuration.
+   * @param cacheBasePath - see {@link fileCached.cacheBasePath}
+   * @param batchSize - see {@link fileCached.batchSize}
+   *
    */
-  static fileCachedBased(arweave: Arweave, cacheBasePath?: string): SmartWeaveBuilder {
+  static fileCachedBased(arweave: Arweave, cacheBasePath?: string, batchSize = DEFAULT_BATCH_SIZE): SmartWeaveBuilder {
     const definitionLoader = new ContractDefinitionLoader(arweave, new MemCache());
 
     const interactionsLoader = new CacheableContractInteractionsLoader(
@@ -38,7 +47,7 @@ export class SmartWeaveNodeFactory extends SmartWeaveWebFactory {
 
     const executorFactory = new CacheableExecutorFactory(arweave, new HandlerExecutorFactory(arweave), new MemCache());
 
-    const stateEvaluator = new CacheableStateEvaluator(arweave, new BsonFileBlockHeightSwCache(cacheBasePath), [
+    const stateEvaluator = new CacheableStateEvaluator(arweave, new FileBlockHeightSwCache(cacheBasePath, batchSize), [
       new Evolve(definitionLoader, executorFactory)
     ]);
 

--- a/src/core/web/SmartWeaveWebFactory.ts
+++ b/src/core/web/SmartWeaveWebFactory.ts
@@ -67,7 +67,11 @@ export class SmartWeaveWebFactory {
    * Returns a preconfigured, memCached {@link SmartWeaveBuilder}, that allows for customization of the SmartWeave instance.
    * Use {@link SmartWeaveBuilder.build()} to finish the configuration.
    */
-  static memCachedBased(arweave: Arweave, maxStoredBlockHeights: number = Number.MAX_SAFE_INTEGER): SmartWeaveBuilder {
+  static memCachedBased(
+    arweave: Arweave,
+    maxStoredBlockHeights: number = Number.MAX_SAFE_INTEGER,
+    stateCache?: MemBlockHeightSwCache<StateCache<unknown>>
+  ): SmartWeaveBuilder {
     const definitionLoader = new ContractDefinitionLoader(arweave, new MemCache());
 
     const interactionsLoader = new CacheableContractInteractionsLoader(
@@ -79,7 +83,7 @@ export class SmartWeaveWebFactory {
 
     const stateEvaluator = new CacheableStateEvaluator(
       arweave,
-      new MemBlockHeightSwCache<StateCache<unknown>>(maxStoredBlockHeights),
+      stateCache ? stateCache : new MemBlockHeightSwCache<StateCache<unknown>>(maxStoredBlockHeights),
       [new Evolve(definitionLoader, executorFactory)]
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1539,10 +1539,10 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
-arlocal@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/arlocal/-/arlocal-1.1.4.tgz#853d371573d1e055f13d0178b02a75de7927d129"
-  integrity sha512-SnQZ4MeRDnnLbkZRaDcq8gZeD1jBbTR6YEpOYD8gV/OhsNhURX/WuzKyzjiNdQCAs+mXpkpnRUNCnGDQE4gfMQ==
+arlocal@1.1.13:
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/arlocal/-/arlocal-1.1.13.tgz#a6875631c867bd377129b964a3aac4253964cf8a"
+  integrity sha512-zT8EZm71UTNtRw2FoxRRuojuUlfCTZOj9dz1uV9Z5tw5jTzB6ZUGCISo4W/G8iTvjAjZFmvFcq0OQW16x8gjEg==
   dependencies:
     "@koa/cors" "^3.1.0"
     apollo-server-koa "^2.25.1"


### PR DESCRIPTION
Changes introduced in this PR (some of them are breaking):
1. `BsonFileBlockHeightSwCache` renamed to `FileBlockHeightSwCache`
2. `FileBlockHeightSwCache` fixed to be compatible with changes introduced in https://github.com/redstone-finance/redstone-smartcontracts/pull/52
3. `FileBlockHeightSwCache` no longer uses the `BSON` file format - as it is incompatible with storing top-level array objects - https://github.com/mongodb/js-bson/issues/319 (storing states in an array for each block height has been introduced in https://github.com/redstone-finance/redstone-smartcontracts/pull/52 - as a remainder, there might be more than one interaction transaction on a given block height)
4. integration tests added for file-cached smartweave client.
5. `FileBlockHeightSwCache` marked as Deprecated.

In case of migration, one should:
1. Deserialize all current files from BSON format (using `BSON.deserialize`)
2. Wrap each deserialized object in an array
3. Serialize objects to JSON and save on filesystem, with the exact same naming convention/directory structure.
