### PR TITLE
Fix: `createTx()` default tag values no longer overwrite user-provided value

### DIFF
--- a/src/legacy/create-tx.ts
+++ b/src/legacy/create-tx.ts
@@ -30,16 +30,15 @@ export async function createTx(
     throw new Error(`Input should be a truthy value: ${JSON.stringify(input)}`);
   }
 
+  interactionTx.addTag('App-Name', 'SmartWeaveAction');
+  interactionTx.addTag('App-Version', '0.3.0'); // User can over-write this via provided tags
+  interactionTx.addTag('Contract', contractId);
+  interactionTx.addTag('Input', JSON.stringify(input));
   if (tags && tags.length) {
     for (const tag of tags) {
       interactionTx.addTag(tag.name.toString(), tag.value.toString());
     }
   }
-  interactionTx.addTag('App-Name', 'SmartWeaveAction');
-  // use real SDK version here?
-  interactionTx.addTag('App-Version', '0.3.0');
-  interactionTx.addTag('Contract', contractId);
-  interactionTx.addTag('Input', JSON.stringify(input));
 
   await arweave.transactions.sign(interactionTx, wallet);
   return interactionTx;


### PR DESCRIPTION
Fix to issue:
https://github.com/redstone-finance/redstone-smartcontracts/issues/83#issue-1107230090