### PR TITLE
feat: allow to create unsigned interaction and post it separately

### DIFF
--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -159,7 +159,7 @@ export interface Contract<State = unknown> {
    * @param transfer - additional {@link ArTransfer} than can be attached to the interaction transaction
    * @param strict - transaction will be posted on Arweave only if the dry-run of the input result is "ok"
    */
-  bundleInteraction<Input = unknown>(input: Input, tags?: Tags, strict?: boolean): Promise<any | null>;
+  bundleInteraction<Input = unknown>(input: Input, tags?: Tags, strict?: boolean): Promise<any>;
 
   /**
    * Post an "interaction" transaction, that has already been created, using RedStone Sequencer -
@@ -172,7 +172,7 @@ export interface Contract<State = unknown> {
    *
    * @param interactionTx - {@link Transaction} to be posted
    */
-  bundleInteractionTx(interactionTx: Transaction): Promise<any | null>;
+  bundleInteractionTx(interactionTx: Transaction): Promise<any>;
 
   /**
    * Creates an unsigned "interaction" transaction and returns it. This allows to sign the

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -8,6 +8,7 @@ import {
   InteractionResult,
   Tags
 } from '@smartweave';
+import Transaction from 'arweave/node/lib/transaction';
 import { NetworkInfoInterface } from 'arweave/node/network';
 
 export type CurrentTx = { interactionTxId: string; contractTxId: string };
@@ -139,6 +140,17 @@ export interface Contract<State = unknown> {
   ): Promise<string | null>;
 
   /**
+   * Posts an "interaction" transaction that has already been created.
+   *
+   * **Note:** This method is useful when the transaction object has already been created with
+   * {@link createUnsignedTransaction} and signed later on. Prefer using {@link writeInteraction}
+   * if control over how the transaction is signed is not needed.
+   *
+   * @param interactionTx - {@link Transaction} to be posted
+   */
+  writeInteractionTx(interactionTx: Transaction): Promise<string | null>;
+
+  /**
    * Creates a new "interaction" transaction using RedStone Sequencer - this, with combination with
    * RedStone Gateway, gives instant transaction availability and finality guaranteed by Bundlr.
    *
@@ -148,6 +160,36 @@ export interface Contract<State = unknown> {
    * @param strict - transaction will be posted on Arweave only if the dry-run of the input result is "ok"
    */
   bundleInteraction<Input = unknown>(input: Input, tags?: Tags, strict?: boolean): Promise<any | null>;
+
+  /**
+   * Post an "interaction" transaction, that has already been created, using RedStone Sequencer -
+   * this, with combination with RedStone Gateway, gives instant transaction availability and finality
+   * guaranteed by Bundlr.
+   *
+   * **Note:** This method is useful when the transaction object has already been created with
+   * {@link createUnsignedTransaction} and signed later on. Prefer using {@link bundleInteraction} if
+   * control over how the transaction is signed is not needed.
+   *
+   * @param interactionTx - {@link Transaction} to be posted
+   */
+  bundleInteractionTx(interactionTx: Transaction): Promise<any | null>;
+
+  /**
+   * Creates an unsigned "interaction" transaction and returns it. This allows to sign the
+   * transaction manually. After being signed, the transaction should be posted using either
+   * {@link writeInteractionTx} or {@link bundleInteractionTx}.
+   *
+   * @param input - new input to the contract that will be assigned with this interactions transaction
+   * @param tags - additional tags that can be attached to the newly created interaction transaction
+   * @param transfer - additional {@link ArTransfer} than can be attached to the interaction transaction
+   * @param strict - transaction will be posted on Arweave only if the dry-run of the input result is "ok"
+   */
+  createUnsignedInteraction<Input>(
+    input: Input,
+    tags: { name: string; value: string }[],
+    transfer: ArTransfer,
+    strict: boolean
+  ): Promise<Transaction>;
 
   /**
    * Returns the full call tree report the last

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -159,7 +159,7 @@ export interface Contract<State = unknown> {
    * @param transfer - additional {@link ArTransfer} than can be attached to the interaction transaction
    * @param strict - transaction will be posted on Arweave only if the dry-run of the input result is "ok"
    */
-  bundleInteraction<Input = unknown>(input: Input, tags?: Tags, strict?: boolean): Promise<any>;
+  bundleInteraction<Input = unknown>(input: Input, tags?: Tags, strict?: boolean): Promise<any | null>;
 
   /**
    * Post an "interaction" transaction, that has already been created, using RedStone Sequencer -
@@ -172,7 +172,7 @@ export interface Contract<State = unknown> {
    *
    * @param interactionTx - {@link Transaction} to be posted
    */
-  bundleInteractionTx(interactionTx: Transaction): Promise<any>;
+  bundleInteractionTx(interactionTx: Transaction): Promise<any | null>;
 
   /**
    * Creates an unsigned "interaction" transaction and returns it. This allows to sign the

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -186,9 +186,9 @@ export interface Contract<State = unknown> {
    */
   createUnsignedInteraction<Input>(
     input: Input,
-    tags: { name: string; value: string }[],
-    transfer: ArTransfer,
-    strict: boolean
+    tags?: Tags,
+    transfer?: ArTransfer,
+    strict?: boolean
   ): Promise<Transaction>;
 
   /**

--- a/src/contract/Contract.ts
+++ b/src/contract/Contract.ts
@@ -147,8 +147,9 @@ export interface Contract<State = unknown> {
    * if control over how the transaction is signed is not needed.
    *
    * @param interactionTx - {@link Transaction} to be posted
+   * @param strict - transaction will be posted on Arweave only if the dry-run of the input result is "ok"
    */
-  writeInteractionTx(interactionTx: Transaction): Promise<string | null>;
+  writeInteractionTx(interactionTx: Transaction, strict?: boolean): Promise<string | null>;
 
   /**
    * Creates a new "interaction" transaction using RedStone Sequencer - this, with combination with
@@ -171,8 +172,9 @@ export interface Contract<State = unknown> {
    * control over how the transaction is signed is not needed.
    *
    * @param interactionTx - {@link Transaction} to be posted
+   * @param strict - transaction will be posted on Arweave only if the dry-run of the input result is "ok"
    */
-  bundleInteractionTx(interactionTx: Transaction): Promise<any | null>;
+  bundleInteractionTx(interactionTx: Transaction, strict?: boolean): Promise<any | null>;
 
   /**
    * Creates an unsigned "interaction" transaction and returns it. This allows to sign the
@@ -182,14 +184,8 @@ export interface Contract<State = unknown> {
    * @param input - new input to the contract that will be assigned with this interactions transaction
    * @param tags - additional tags that can be attached to the newly created interaction transaction
    * @param transfer - additional {@link ArTransfer} than can be attached to the interaction transaction
-   * @param strict - transaction will be posted on Arweave only if the dry-run of the input result is "ok"
    */
-  createUnsignedInteraction<Input>(
-    input: Input,
-    tags?: Tags,
-    transfer?: ArTransfer,
-    strict?: boolean
-  ): Promise<Transaction>;
+  createUnsignedInteraction<Input>(input: Input, tags?: Tags, transfer?: ArTransfer): Promise<Transaction>;
 
   /**
    * Returns the full call tree report the last

--- a/src/contract/HandlerBasedContract.ts
+++ b/src/contract/HandlerBasedContract.ts
@@ -215,7 +215,7 @@ export class HandlerBasedContract<State> implements Contract<State> {
   }
 
   async writeInteractionTx(interactionTx: Transaction): Promise<string | null> {
-    this.smartweave.arweave.transactions.verify(interactionTx);
+    await this.smartweave.arweave.transactions.verify(interactionTx);
 
     this.logger.info('Write interaction tx', interactionTx.id);
     const response = await this.smartweave.arweave.transactions.post(interactionTx);
@@ -234,7 +234,7 @@ export class HandlerBasedContract<State> implements Contract<State> {
     return interactionTx.id;
   }
 
-  async bundleInteraction<Input>(input: Input, tags: Tags = [], strict = false): Promise<any> {
+  async bundleInteraction<Input>(input: Input, tags: Tags = [], strict = false): Promise<any | null> {
     this.logger.info('Bundle interaction input', input);
     if (!this.wallet) {
       throw new Error("Wallet not connected. Use 'connect' method first.");
@@ -245,8 +245,8 @@ export class HandlerBasedContract<State> implements Contract<State> {
     return this.bundleInteractionTx(interactionTx);
   }
 
-  async bundleInteractionTx(interactionTx: Transaction): Promise<any> {
-    this.smartweave.arweave.transactions.verify(interactionTx);
+  async bundleInteractionTx(interactionTx: Transaction): Promise<any | null> {
+    await this.smartweave.arweave.transactions.verify(interactionTx);
 
     this.logger.info('Bundle interaction tx', interactionTx.id);
     const response = await fetch(`${this._evaluationOptions.bundlerAddress}gateway/sequencer/register`, {

--- a/src/contract/HandlerBasedContract.ts
+++ b/src/contract/HandlerBasedContract.ts
@@ -215,6 +215,8 @@ export class HandlerBasedContract<State> implements Contract<State> {
   }
 
   async writeInteractionTx(interactionTx: Transaction): Promise<string | null> {
+    this.smartweave.arweave.transactions.verify(interactionTx);
+
     this.logger.info('Write interaction tx', interactionTx.id);
     const response = await this.smartweave.arweave.transactions.post(interactionTx);
 
@@ -232,7 +234,7 @@ export class HandlerBasedContract<State> implements Contract<State> {
     return interactionTx.id;
   }
 
-  async bundleInteraction<Input>(input: Input, tags: Tags = [], strict = false): Promise<any | null> {
+  async bundleInteraction<Input>(input: Input, tags: Tags = [], strict = false): Promise<any> {
     this.logger.info('Bundle interaction input', input);
     if (!this.wallet) {
       throw new Error("Wallet not connected. Use 'connect' method first.");
@@ -244,6 +246,8 @@ export class HandlerBasedContract<State> implements Contract<State> {
   }
 
   async bundleInteractionTx(interactionTx: Transaction): Promise<any> {
+    this.smartweave.arweave.transactions.verify(interactionTx);
+
     this.logger.info('Bundle interaction tx', interactionTx.id);
     const response = await fetch(`${this._evaluationOptions.bundlerAddress}gateway/sequencer/register`, {
       method: 'POST',

--- a/src/contract/HandlerBasedContract.ts
+++ b/src/contract/HandlerBasedContract.ts
@@ -278,9 +278,9 @@ export class HandlerBasedContract<State> implements Contract<State> {
 
   async createUnsignedInteraction<Input>(
     input: Input,
-    tags: { name: string; value: string }[],
-    transfer: ArTransfer,
-    strict: boolean
+    tags: Tags = [],
+    transfer = emptyTransfer,
+    strict = false
   ): Promise<Transaction> {
     this.logger.info('Unsigned interaction input', input);
     if (this._evaluationOptions.internalWrites) {

--- a/src/legacy/create-tx.ts
+++ b/src/legacy/create-tx.ts
@@ -13,6 +13,20 @@ export async function createTx(
   target = '',
   winstonQty = '0'
 ): Promise<Transaction> {
+  const tx = await createUnsignedTx(arweave, contractId, input, tags, target, winstonQty);
+  await arweave.transactions.sign(tx, wallet);
+
+  return tx;
+}
+
+export async function createUnsignedTx(
+  arweave: Arweave,
+  contractId: string,
+  input: any,
+  tags: { name: string; value: string }[],
+  target = '',
+  winstonQty = '0'
+): Promise<Transaction> {
   const options: Partial<CreateTransactionInterface> = {
     data: Math.random().toString().slice(-4)
   };
@@ -24,7 +38,7 @@ export async function createTx(
     }
   }
 
-  const interactionTx = await arweave.createTransaction(options, wallet);
+  const interactionTx = await arweave.createTransaction(options);
 
   if (!input) {
     throw new Error(`Input should be a truthy value: ${JSON.stringify(input)}`);
@@ -42,7 +56,6 @@ export async function createTx(
   interactionTx.addTag(SmartWeaveTags.CONTRACT_TX_ID, contractId);
   interactionTx.addTag(SmartWeaveTags.INPUT, JSON.stringify(input));
 
-  await arweave.transactions.sign(interactionTx, wallet);
   return interactionTx;
 }
 


### PR DESCRIPTION
This PR shouldn't include any breaking changes. It'll allow users to obtain an unsigned `Transaction` object of a write interaction in order to sign it manually and then post it as a bundle or simply through arweave.net as a second step.

To obtain said unsigned `Transaction`, I replaced `createInteraction` with `createUnsignedInteraction` and made it public. I also had to write a `createUnsignedTx` function in `src/legacy/create-tx.ts` that the original `createTx` now uses. The user can use this method, sign the returned object and pass it to `writeInteractionTx` or `bundleInteractionTx`.

I adapted `writeInteraction` and `bundleInteraction` to the new `createUnsignedInteraction`. They now call it and then sign it with `arweave.transactions.sign(tx, this.wallet)`.

I haven't tested it yet, I will report back on monday for this. The modifications being light it should be ok but we never know!
