### PR TITLE
CHG: Provide esm browser bundler for modern browser runtimes

### DIFF
--- a/bundle.js
+++ b/bundle.js
@@ -51,6 +51,21 @@ const runBuild = async () => {
     console.log(e);
     process.exit(1);
   });
+
+  build({
+    entryPoints: ['./src/index.ts'],
+    minify: true,
+    bundle: true,
+    outfile: './bundles/esm.bundle.min.js',
+    platform: 'browser',
+    target: ['es2020', 'chrome58', 'firefox57', 'safari11'],
+    format: 'esm',
+    globalName: 'rsdk'
+  }).catch((e) => {
+    console.log(e);
+    process.exit(1);
+  });
+
 };
 runBuild();
 

--- a/bundle.js
+++ b/bundle.js
@@ -37,6 +37,20 @@ const runBuild = async () => {
     console.log(e);
     process.exit(1);
   });
+
+  build({
+    entryPoints: ['./src/index.ts'],
+    minify: false,
+    bundle: true,
+    outfile: './bundles/esm.bundle.js',
+    platform: 'browser',
+    target: ['es2020', 'chrome58', 'firefox57', 'safari11'],
+    format: 'esm',
+    globalName: 'rsdk'
+  }).catch((e) => {
+    console.log(e);
+    process.exit(1);
+  });
 };
 runBuild();
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,14 @@
   "main": "./lib/cjs/index.js",
   "module": "./lib/esm/index.js",
   "types": "./lib/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/esm/index.js",
+      "require": "./lib/cjs/index.js"
+    },
+    "./esm": "bundles/esm.bundle.js",
+    "./web": "bundles/web.bundle.js"
+  },
   "sideEffects": false,
   "engines": {
     "node": ">=16.5"


### PR DESCRIPTION
This PR, extends the "esbuild" script to include an ESM bundle targeted at modern browsers and browser runtimes. This may not be the final solution to support tools like "vite" and "rollup", but it should be a good stopgap.

## Usage

```js
import * as SW from 'redstone-smartweave/esm"

const smartweave = SW.SmartWeaveWebFactory.memCachedBased(arweave).build();

```